### PR TITLE
Remove eunit from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@
 .PHONY: doc
 
 all:
-	./rebar compile eunit
+	./rebar compile
+
+test: eunit qc
 
 doc:
 	./rebar doc
@@ -27,6 +29,9 @@ clean:
 
 dialyzer:
 	./rebar analyze
+
+eunit:
+	./rebar eunit
 
 qc:
 	./rebar qc


### PR DESCRIPTION
I'm using [erlang.mk](https://github.com/ninenines/erlang.mk) and having `eunit` as part of the default target is kind of annoying, because every time I run my tests the `triq` EUnit tests are run first.
This is because erlang.mk simply calls `make -C deps/triq`, which will call the default target.

GNU defines some ["standard" targets](https://www.gnu.org/prep/standards/html_node/Standard-Targets.html), in which they say that `all` should basically just compile the entire program.

This PR removes the `eunit` switch from the default target and adds two new ones:

`eunit`: To run the EUnit tests
`test`: Run the `eunit` and `qc` targets
