### PR TITLE
More aggressive shrinker for choose/2

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -1063,10 +1063,9 @@ choose_pick(#?DOM{kind=#choose{min=M,max=N}}=Dom, _) ->
     Value = random:uniform(N-M+1) - 1 + M,
     {Dom,Value}.
 
-choose_shrink(#?DOM{kind=#choose{min=M}}=Dom, Value) when Value > M ->
-    {Dom,Value-1};
-choose_shrink(#?DOM{kind=#choose{min=M}}=Dom, M) ->
-    {Dom,M}.
+choose_shrink(#?DOM{kind=#choose{min=M}}=Dom, Value) ->
+    Mid = (Value - M) div 2,
+    {Dom, M + Mid}.
 
 %% @doc Generates a member of the list `L'.  Shrinks towards the first element
 %% of the list.


### PR DESCRIPTION
The old shrinker would simply subtract one from the current value, which was ineffective when shrinking large ranges (e.g. `choose(0, 16#ffffffff)`).  This new shrinker converges towards min by repeatedly halving the difference between current value and min.  Below are outputs from sample shrink:

Old Shrinker

``` erlang
$ erl -pa ebin/ -noshell \
      -eval "triq_dom:sampleshrink(triq_dom:choose(0,16#ffffffff))" \
      -eval "init:stop()"
1905181424
[1905181423]
[1905181422]
[1905181421]
[1905181420]
[1905181419]
[1905181418]
[1905181417]
[1905181416]
[1905181415]
[1905181414]
% goes on forever
```

New Shrinker

``` erlang
$ erl -pa ebin/ -noshell \
      -eval "triq_dom:sampleshrink(triq_dom:choose(0,16#ffffffff))"  \
      -eval "init:stop()"
1905181424
[952590712]
[476295356]
[238147678]
[119073839]
[59536919]
[29768459]
[14884229]
[7442114]
[3721057]
[1860528]
[930264]
[465132]
[232566]
[116283]
[58141]
[29070]
[14535]
[7267]
[3633]
[1816]
[908]
[454]
"ã"
"q"
"8"
[28]
[14]
[7]
[3]
[1]
[0]
```
