### PR TITLE
Increased level of randomness

### DIFF
--- a/src/triq.erl
+++ b/src/triq.erl
@@ -327,6 +327,7 @@ check(Property, CounterExample) when is_list(CounterExample) ->
 %% @end
 %%--------------------------------------------------------------------
 check(Property, Counterexample, RunIters) ->
+    generate_randomness(),
     case check_input(fun(nil)->Property end,
                      nil,
                      nil,
@@ -455,3 +456,11 @@ fails(Prop) ->
     {'prop:fails', Prop}.
 numtests(Num,Prop) ->
     {'prop:numtests', Num, Prop}.
+
+%%
+%% 12 crypto-safe random bytes to seed erlang random number generator
+%%
+generate_randomness() ->
+    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
+    random:seed({A, B, C}),
+    io:format("Seed: ~p~n", [{A, B, C}]).


### PR DESCRIPTION
The Erlang random number generator does not have an high level of randomness because it is based on a default seed and the result is that each Triq run generates the same random values.

Here are the domains of the following examples:

``` erlang
time_dom() ->
    {choose(0, 23), choose(0, 59), choose(0, 59)}.
delta_dom() ->
    {choose(0, 3), choose(0, 9), choose(0, 9)}.  
```

Before the explicit random seed:

``` erlang
%% first run
{19,24,48}, {0,7,1}
{1,6,46}, {0,9,0}
{5,21,7}, {3,8,2}
{13,36,8}, {0,7,6}
{12,7,24}, {0,5,8}
{4,19,4}, {2,2,6}
{2,37,34}, {1,1,5}

%% second run
{19,24,48}, {0,7,1}
{1,6,46}, {0,9,0}
{5,21,7}, {3,8,2}
{13,36,8}, {0,7,6}
{12,7,24}, {0,5,8}
{4,19,4}, {2,2,6}
{2,37,34}, {1,1,5}
```

After the explicit random seed:

``` erlang
%% first run
{5,5,17}, {3,7,2}
{18,7,21}, {0,6,4}
{17,34,7}, {0,9,6}
{16,42,15}, {3,0,9}
{6,37,1}, {0,9,6}
{3,17,19}, {1,3,6}
{9,6,18}, {0,9,0}

%% second run
{11,8,8}, {3,9,5}
{19,17,24}, {1,9,8}
{18,47,28}, {1,0,7}
{0,39,43}, {0,8,4}
{10,23,15}, {1,8,1}
{10,35,7}, {1,4,6}
{9,25,5}, {0,6,6}
```

I have created a triq:generate_randomness/0 function which uses crypto module to improve the randomness and it is invoked in triq:check/3 which (if I am not wrong) is the function that finally checks a property.

So Triq now generates random values with a different seed for each property.
