### PR TITLE
Vagrant dev environment for Triq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc/stylesheet.css
 *.beam
 *.S
 *.erlx
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,123 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, path: "provisioning.sh"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with CFEngine. CFEngine Community packages are
+  # automatically installed. For example, configure the host as a
+  # policy server and optionally a policy file to run:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.am_policy_hub = true
+  #   # cf.run_file = "motd.cf"
+  # end
+  #
+  # You can also configure and bootstrap a client to an existing
+  # policy server:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.policy_server_address = "10.0.2.15"
+  # end
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file default.pp in the manifests_path directory.
+  #
+  # config.vm.provision "puppet" do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "default.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { mysql_password: "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y curl
+printf "curl correctly installed"
+apt-get install -y git
+printf "git correctly installed"
+
+apt-get install -y build-essential libncurses5-dev openssl libssl-dev fop xsltproc unixodbc-dev
+printf "Erlang dependencies are correctly installed\n"
+
+cd /usr/bin
+curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl 2> /dev/null
+chmod a+x kerl
+printf "kerl correctly installed"
+
+printf "** Provisioning completed **"


### PR DESCRIPTION
Since we are doing continuous integration on more than one Erlang version and there are issues that seems to happen on specific versions (for example the issue #33), here is a development environment for Triq which is able to support fast erlang version changes thanks to [Kerl](https://github.com/yrashk/kerl).

The set-up is really easy an it is up to the developer to log into the VM and use kerl to install a specific Erlang version, (linking Triq in the include directory of the choosen version).

Example:

```shell
vagrant@vagrant-ubuntu-trusty-64:~$ kerl list releases
R10B-0 R10B-10 R10B-1a R10B-2 R10B-3 R10B-4 R10B-5 R10B-6 R10B-7 R10B-8 R10B-9 R11B-0 R11B-1 R11B-2 R11B-3 R11B-4 R11B-5 R12B-0 R12B-1 R12B-2 R12B-3 R12B-4 R12B-5 R13A R13B01 R13B02-1 R13B02 R13B03 R13B04 R13B R14A R14B01 R14B02 R14B03 R14B04 R14B R14B_erts-5.8.1.1 R15B01 R15B02 R15B02_with_MSVCR100_installer_fix R15B03-1 R15B03 R15B R16A_RELEASE_CANDIDATE R16B01 R16B02 R16B03-1 R16B03 R16B 17.0-rc1 17.0-rc2 17.0 17.1 17.3
Run "/usr/bin/kerl update releases" to update this list from erlang.org
vagrant@vagrant-ubuntu-trusty-64:~$ kerl build R16B03 r16b03
...
vagrant@vagrant-ubuntu-trusty-64:~$ mkdir ~/r16b03
vagrant@vagrant-ubuntu-trusty-64:~$ kerl install r16b03 ~/r16b03
vagrant@vagrant-ubuntu-trusty-64:~$ kerl list installations
r16b03 /home/vagrant/r16b03
vagrant@vagrant-ubuntu-trusty-64:~$ . ~/r16b03/activate
vagrant@vagrant-ubuntu-trusty-64:~$ ln -s /vagrant ~/r16b03/lib/triq
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./rebar compile qc
==> vagrant (compile)
==> vagrant (qc)
NOTICE: Using experimental 'qc' command
Testing lock_fsm:prop_lock_fsm/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_unicode_char/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_unicode_binary/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_sized_unicode_binary/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_unicode_string/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_unicode_characters/0
....................................................................................................
Ran 100 tests
Testing triq_unicode_tests:prop_unicode_external_characters/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_pos_integer/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_non_neg_integer/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_append/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_binop/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_timeout/0
...Failed with: {timeout,100}

Ran 1 tests
Testing triq_tests:prop_sized/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_simple1/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_simple2/0
....................................................................................................
Ran 100 tests
Testing triq_tests:prop_simple3/0
................................................x.........................................x.........
Ran 98 tests
Testing triq_tests:prop_suchthat/0
....................................................................................................
Ran 100 tests
Testing pdict_statem:prop_pdict_statem/0
....................................................................................................
Ran 100 tests
```

So, change the version of Erlang is only a matter of `kerl_deactivate` and `. <path_to_the_erlang_version/activate>`.
More documentation about kerl is available [here](https://github.com/yrashk/kerl).

@krestenkrab I tried lots of runs on the R16B03 but I am not able to reproduce the issue. I will come back on the issue #33 after I have finished the task about the seed injection.