### PR TITLE
parse transform fix: triq:test/1 -> triq:check/1

### DIFF
--- a/src/triq_autoexport.erl
+++ b/src/triq_autoexport.erl
@@ -65,7 +65,7 @@ rewrite([], As, Module, GenQC) ->
     {if GenQC ->
              [{function,0,?CHECK,0,
                [{clause,0,[],[],
-                 [{call,0,{remote,0,{atom,0,triq},{atom,0,test}},
+                 [{call,0,{remote,0,{atom,0,triq},{atom,0,check}},
                    [{atom,0,Module}]}]}]}
               | As];
         true ->


### PR DESCRIPTION
the autogenerated function :check/0 in the parse transform was calling triq:test/1, and failing with 

*\* exception error: undefined function triq:test/1

should instead be calling triq:check/1 I believe (and changing it that way seems to work).
