### PR TITLE
Fix int/2 generator

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -585,7 +585,7 @@ int(Min, Max) ->
                     (Dom,0) -> {Dom,0}
                  end,
           pick=fun(Dom,SampleSize) ->
-                       {Dom, random:uniform(max(SampleSize, Diff)) + Min}
+                       {Dom, random:uniform(min(SampleSize, Diff)) + Min}
                end
          }.
 

--- a/test/triq_tests.erl
+++ b/test/triq_tests.erl
@@ -36,6 +36,19 @@ boolean_test() ->
     Unique = fun ordsets:from_list/1,
     ?assertEqual([false, true], Unique(triq_dom:sample(bool()))).
 
+prop_intrange() ->
+    ?FORALL({X,Y},
+            ?SUCHTHAT({XX,YY},
+                      {int(), int()},
+                      XX < YY),
+
+            true = triq:counterexample( prop_intrange(X,Y))).
+
+prop_intrange(X,Y) when X < Y ->
+    ?FORALL(I, int(X,Y),
+            ?WHENFAIL(io:format("Min=~p, Max=~p, I=~p~n", [X,Y,I]),
+                      (I >= X) andalso (I =< Y))).
+
 prop_pos_integer() ->
     ?FORALL(PosInt, pos_integer(), PosInt > 0).
 


### PR DESCRIPTION
The issue was that the maximum value picked for the generator was
the highest between SampleSize (which is potentially very big)
and Diff (which is the real maximum we don't want to cross).
Instead we now pick the lowest, ensuring that we won't generate
a value bigger than Diff.

Tests suggested by @krestenkrab.

The test output now looks a little weird though ahah:

```
Testing triq_tests:prop_intrange/0
....................................................................................................
Ran 100 tests
.....................................................................................................
Ran 100 tests
.....................................................................................................
Ran 100 tests
.....................................................................................................
Ran 100 tests
.....................................................................................................
Ran 100 tests
.....................................................................................................
Ran 100 tests
.....................................................................................................
...
```

But I suppose this is harmless. :-)
