### PR TITLE
changes int range generator to range across full given range

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -584,8 +584,8 @@ int(Min, Max) ->
                     (Dom,Val) when Val<0 -> {Dom,Val+1};
                     (Dom,0) -> {Dom,0}
                  end,
-          pick=fun(Dom,SampleSize) ->
-                       {Dom, random:uniform(min(SampleSize, Diff)) + Min}
+          pick=fun(Dom,_SampleSize) ->
+                       {Dom, random:uniform(Diff) + Min}
                end
          }.
 


### PR DESCRIPTION
changes the int(L,M) range generator to always range between L and M, regardless of samplesize.