### PR TITLE
more versions of erlang in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: erlang
 otp_release:
    - R16B03
    - R15B03
+   - R16B03-1
+   - R16B02
+   - R16B01
+   - 17.0
+   - 17.1
+   - 17.3


### PR DESCRIPTION
In order to test vs Erlang 17.x and more of 16.x a change to the build file