### PR TITLE
Don't bail compilation on warnings.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,3 @@
-{erl_opts, [warnings_as_errors]}.
 {cover_enabled, true}.
 {erl_first_files, ["src/triq_autoexport.erl"]}.
 {qc_opts, [{qc_mod, triq}]}.


### PR DESCRIPTION
Needed to compile on Erlang 19 (though, of course, the real solution is to fix the warnings).
